### PR TITLE
fix: render empty Wrapper in Screener if no screener is yet selected

### DIFF
--- a/src/app/screener/page.tsx
+++ b/src/app/screener/page.tsx
@@ -12,7 +12,7 @@ function Wrapper({
   selectedScreener,
   setSelectedScreener,
 }: {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   selectedScreener: string | null;
   setSelectedScreener: (screener: string) => void;
 }) {
@@ -30,6 +30,10 @@ function Wrapper({
 export default function ScreenerPage() {
   const [selectedScreener, setSelectedScreener] = useState<string | null>(null);
   const { data, isLoading, error } = useQuery(screenerQuery(selectedScreener));
+
+  if (!selectedScreener) {
+    return <Wrapper selectedScreener={selectedScreener} setSelectedScreener={setSelectedScreener} />;
+  }
 
   if (selectedScreener && isLoading) {
     return (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the screener page to only display the picker UI when no screener is selected, preventing unnecessary loading or error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->