### PR TITLE
Remove dynamic investment amount and add manual refresh for investment plan

### DIFF
--- a/src/app/(protected)/plan/components/page/PlanHeader.tsx
+++ b/src/app/(protected)/plan/components/page/PlanHeader.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import { TimePassed } from '@/components/TimePassed';
-import { BrainIcon, ClockIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { useRefreshInvestmentPlan } from '@/mutations/useRefreshInvestmentPlan';
+import { investmentPlanQuery } from '@/queries/investmentPlanQuery';
+import { useQuery } from '@tanstack/react-query';
+import { BrainIcon, ClockIcon, RefreshCcwIcon } from 'lucide-react';
 
 interface PlanHeaderProps {
   title: string;
@@ -9,19 +14,41 @@ interface PlanHeaderProps {
 }
 
 export function PlanHeader({ title, createdAt }: PlanHeaderProps) {
+  const { isFetching } = useQuery(investmentPlanQuery);
+  const { mutate: refreshInvestmentPlan, isPending: isRefreshing } = useRefreshInvestmentPlan();
+
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-center gap-3">
-        <div className="p-2 bg-primary/10 rounded-lg">
-          <BrainIcon className="h-6 w-6 text-primary" />
+    <header className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-primary/10 rounded-lg">
+            <BrainIcon className="h-6 w-6 text-primary" />
+          </div>
+          <h1 className="text-2xl font-bold">{title}</h1>
         </div>
-        <h1 className="text-2xl font-bold">{title}</h1>
+
+        <Button
+          variant="outline"
+          className={cn('h-8 w-8', {
+            'cursor-pointer': !isFetching && !isRefreshing,
+            'cursor-not-allowed': isFetching || isRefreshing,
+          })}
+          onClick={() => refreshInvestmentPlan()}
+          disabled={isFetching || isRefreshing}
+        >
+          <RefreshCcwIcon
+            className={cn('h-4 w-4', {
+              'animate-spin': isFetching || isRefreshing,
+            })}
+          />
+        </Button>
       </div>
+
       <div className="flex items-center gap-1 text-muted-foreground">
         <ClockIcon className="w-4 h-4 mr-1" />
         <span>Generado</span>
         <TimePassed date={createdAt} className="text-base" />
       </div>
-    </div>
+    </header>
   );
 }

--- a/src/app/(protected)/plan/components/stock/StockInvestmentPlan.tsx
+++ b/src/app/(protected)/plan/components/stock/StockInvestmentPlan.tsx
@@ -7,8 +7,10 @@ import { AnalysisButton, EntryPriceRange, ExitStrategy, InvestmentMetrics, Stock
 
 export function StockInvestmentPlan({
   plan,
+  investmentAmount,
 }: {
   plan: InvestmentPlanResponse['response']['investmentSuggestions'][number];
+  investmentAmount: number;
 }) {
   const { data: stockInfo } = useSuspenseQuery(stockInfoQuery(plan.symbol));
 
@@ -36,7 +38,7 @@ export function StockInvestmentPlan({
         <EntryPriceRange minPrice={plan.entryPriceMin} maxPrice={plan.entryPriceMax} />
 
         <InvestmentMetrics
-          quantityToInvest={plan.quantityToInvest}
+          quantityToInvest={plan.quantityToInvest * investmentAmount}
           stopLossPrice={plan.stopLossPrice}
           estimatedTime={plan.estimatedTime}
           estimatedProfitPercentage={plan.estimatedProfitPercentage}

--- a/src/app/(protected)/plan/components/ui/StocksList.tsx
+++ b/src/app/(protected)/plan/components/ui/StocksList.tsx
@@ -12,7 +12,13 @@ const COLUMN_HEIGHT = 564;
 const COLUMN_GAP = 16;
 const ITEM_WIDTH = COLUMN_WIDTH + COLUMN_GAP;
 
-export function StocksList({ data }: { data: InvestmentPlanResponse['response']['investmentSuggestions'] }) {
+export function StocksList({
+  data,
+  investmentAmount,
+}: {
+  data: InvestmentPlanResponse['response']['investmentSuggestions'];
+  investmentAmount: number;
+}) {
   const sortedData = useMemo(() => data.toSorted((a, b) => b.quantityToInvest - a.quantityToInvest), [data]);
 
   const Column = ({ index, style }: { index: number; style: React.CSSProperties }) => {
@@ -23,7 +29,7 @@ export function StocksList({ data }: { data: InvestmentPlanResponse['response'][
         <div style={{ width: COLUMN_WIDTH, height: COLUMN_HEIGHT - 16 }}>
           <StockInvestmentErrorBoundary symbol={item.symbol}>
             <Suspense fallback={<StockInvestmentPlanSkeleton />}>
-              <StockInvestmentPlan plan={item} />
+              <StockInvestmentPlan plan={item} investmentAmount={investmentAmount} />
             </Suspense>
           </StockInvestmentErrorBoundary>
         </div>

--- a/src/app/(protected)/plan/page.tsx
+++ b/src/app/(protected)/plan/page.tsx
@@ -4,8 +4,10 @@ import { investmentPlanQuery } from '@/queries/investmentPlanQuery';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { InvestmentStrategyCard, PlanHeader, StocksList } from './components';
 
+const INVESTMENT_AMOUNT = 3980;
+
 export default function PlanPage() {
-  const { data: stocks } = useSuspenseQuery(investmentPlanQuery(3980));
+  const { data: stocks } = useSuspenseQuery(investmentPlanQuery);
   const investmentPlan = stocks.response;
 
   return (
@@ -13,14 +15,14 @@ export default function PlanPage() {
       <PlanHeader title="Plan de inversión" createdAt={investmentPlan.createdAt} />
 
       <InvestmentStrategyCard
-        investmentAmount={investmentPlan.investmentAmount}
+        investmentAmount={INVESTMENT_AMOUNT}
         expectedProfit={investmentPlan.expectedProfit}
         expectedLoss={investmentPlan.expectedLoss}
         timeframe={investmentPlan.timeframe}
         overallStrategyReasoning={investmentPlan.overallStrategyReasoning}
       />
 
-      <StocksList data={investmentPlan.investmentSuggestions} />
+      <StocksList data={investmentPlan.investmentSuggestions} investmentAmount={INVESTMENT_AMOUNT} />
     </div>
   );
 }

--- a/src/app/api/apiRoutes.ts
+++ b/src/app/api/apiRoutes.ts
@@ -24,9 +24,8 @@ export type API_ROUTES_QUERY = {
   screener: {
     screener: Screeners;
   };
-  investmentPlan: {
-    investmentCapital: number;
-  };
+  investmentPlan: never;
+  refreshInvestmentPlan: never;
   stocksSearch: {
     query: string;
     exchange?: string;
@@ -42,6 +41,7 @@ export const API_ROUTES = {
   refreshAiAnalysis: 'refreshAiAnalysis',
   screener: 'screener',
   investmentPlan: 'investmentPlan',
+  refreshInvestmentPlan: 'refreshInvestmentPlan',
   stocksSearch: 'stocksSearch',
 } as const satisfies Record<keyof API_ROUTES_QUERY, keyof typeof API_ROUTES_URLS>;
 
@@ -54,6 +54,7 @@ export const API_ROUTES_URLS = {
   fetchGeneratedAiAnalysis: '/api/analysis/generated',
   screener: '/api/screener',
   investmentPlan: '/api/investment-plan',
+  refreshInvestmentPlan: '/api/investment-plan/refresh',
   stocksSearch: '/api/stocks/search',
 } as const satisfies Record<keyof API_ROUTES_QUERY, string>;
 
@@ -70,5 +71,9 @@ export type API_ROUTES_RESPONSE = {
   };
   screener: StockScreenerResponse[];
   investmentPlan: InvestmentPlanResponse;
+  refreshInvestmentPlan: {
+    message: string;
+    success: boolean;
+  };
   stocksSearch: SymbolSearchResponse[];
 };

--- a/src/app/api/investment-plan/refresh/route.ts
+++ b/src/app/api/investment-plan/refresh/route.ts
@@ -4,10 +4,25 @@ import { withPosthog } from "@/server/posthog/logPosthogApiCall";
 import { Effect } from "effect";
 import { NextResponse } from "next/server";
 
+const INVESTMENT_PLAN_CACHE_KEY = 'investmentPlan';
+
 export const GET = withRequiredUser(
   withPosthog(async () => {
-    const removedKeysCount = await Effect.runPromise(removeCache('investmentPlan'));
+    try {
+      const removedKeysCount = await Effect.runPromise(removeCache(INVESTMENT_PLAN_CACHE_KEY));
 
-    return NextResponse.json({ message: `Cache removed ${removedKeysCount} keys`, success: removedKeysCount > 0 });
+      return NextResponse.json({ message: `Cache removed ${removedKeysCount} keys`, success: removedKeysCount > 0 });
+    } catch (error) {
+      console.error('Failed to remove cache:', error);
+
+      return NextResponse.json(
+        {
+          message: 'Failed to refresh investment plan cache',
+          success: false,
+          error: error instanceof Error ? error.message : 'Unknown error occurred',
+        },
+        { status: 500 },
+      );
+    }
   }),
 );

--- a/src/app/api/investment-plan/refresh/route.ts
+++ b/src/app/api/investment-plan/refresh/route.ts
@@ -1,0 +1,13 @@
+import { withRequiredUser } from "@/lib/requireUser";
+import { removeCache } from "@/server/cache/removeCache";
+import { withPosthog } from "@/server/posthog/logPosthogApiCall";
+import { Effect } from "effect";
+import { NextResponse } from "next/server";
+
+export const GET = withRequiredUser(
+  withPosthog(async () => {
+    const removedKeysCount = await Effect.runPromise(removeCache('investmentPlan'));
+
+    return NextResponse.json({ message: `Cache removed ${removedKeysCount} keys`, success: removedKeysCount > 0 });
+  }),
+);

--- a/src/app/api/investment-plan/route.ts
+++ b/src/app/api/investment-plan/route.ts
@@ -10,17 +10,12 @@ import { Effect } from 'effect';
 import { NextResponse } from 'next/server';
 
 export const GET = withRequiredUser(
-  withPosthog(async (request) => {
-    const investmentCapital = Number(request.nextUrl.searchParams.get('investmentCapital'));
-    if (isNaN(investmentCapital)) {
-      return NextResponse.json({ error: 'Invalid investment capital, it should cast to a number' }, { status: 400 });
-    }
-
+  withPosthog(async () => {
     const data = await Effect.runPromise(
       withCacheEffect(
         'investmentPlan',
         24 * 60 * 60,
-        generateInvestmentPlan(investmentCapital).pipe(
+        generateInvestmentPlan().pipe(
           Effect.provideService(ScreenerService, TradingViewScreener),
           Effect.provideService(StocksService, FinnhubStocksService),
         ),

--- a/src/mutations/useRefreshInvestmentPlan.ts
+++ b/src/mutations/useRefreshInvestmentPlan.ts
@@ -1,0 +1,16 @@
+import { API_ROUTES } from '@/app/api/apiRoutes';
+import { callNextApi } from '@/lib/callNextApi';
+import { investmentPlanQuery } from '@/queries/investmentPlanQuery';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export function useRefreshInvestmentPlan() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ['investmentPlan', 'refresh'],
+    mutationFn: callNextApi(API_ROUTES.refreshInvestmentPlan),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: investmentPlanQuery.queryKey });
+    },
+  });
+}

--- a/src/queries/investmentPlanQuery.ts
+++ b/src/queries/investmentPlanQuery.ts
@@ -2,9 +2,8 @@ import { API_ROUTES } from '@/app/api/apiRoutes';
 import { callNextApi } from '@/lib/callNextApi';
 import { queryOptions } from '@tanstack/react-query';
 
-export const investmentPlanQuery = (investmentCapital: number) =>
-  queryOptions({
-    queryKey: ['investmentPlan', investmentCapital],
-    queryFn: callNextApi(API_ROUTES.investmentPlan, { query: { investmentCapital } }),
-    staleTime: Infinity,
-  });
+export const investmentPlanQuery = queryOptions({
+  queryKey: ['investmentPlan'],
+  queryFn: callNextApi(API_ROUTES.investmentPlan),
+  staleTime: Infinity,
+});

--- a/src/server/analysis/prompts/index.ts
+++ b/src/server/analysis/prompts/index.ts
@@ -21,7 +21,7 @@ export const PROMPTS = {
   },
   INVESTMENT_PLAN: {
     path: () => import('./investment_plan_prompt.md'),
-    replaces: ['StocksAnalysis', 'InvestmentCapital'],
+    replaces: ['StocksAnalysis'],
   },
 } as const;
 

--- a/src/server/analysis/prompts/investment_plan_prompt.md
+++ b/src/server/analysis/prompts/investment_plan_prompt.md
@@ -1,5 +1,5 @@
 <SystemPrompt>
-  You are an expert investment advisor. Your task is to consolidate and interpret the individual stock analysis recommendations provided by another AI agent. Based on these recommendations and a given total investment quantity, you will generate a concise and actionable investment suggestion for each stock, prioritizing potential profitability while also providing a comprehensive overview of the overall investment strategy. You need to identify the most promising investment opportunities, even if they carry a higher risk, aligning with the user's preference for profitability over strict risk aversion. Only some of these stocks, but not all necessarily should be included in the plan.
+  You are an expert investment advisor. Your task is to consolidate and interpret the individual stock analysis recommendations provided by another AI agent. Based on these recommendations you will generate a concise and actionable investment suggestion for each stock, prioritizing potential profitability while also providing a comprehensive overview of the overall investment strategy. You need to identify the most promising investment opportunities, even if they carry a higher risk, aligning with the user's preference for profitability over strict risk aversion. Only some of these stocks, but not all necessarily should be included in the plan.
 
 Your analysis should consider:
 
@@ -46,8 +46,6 @@ Your analysis should consider:
 
 <StocksAnalysis />
 
-<InvestmentCapital />
-
 <EmpathyInstructions>
   The final output will be used directly by a human investor to make real-money trading decisions (parsed by a program thus the JSON format). Therefore, accuracy, clarity, and actionable insights are paramount. Your recommendations must be well-structured, easy to understand, and directly applicable. The overall strategy justification should be insightful, explaining the rationale behind the investment allocation and risk appetite. The probabilistic assessment should be intuitively understandable and grounded in the `stockAnalysisSummary` for each respective stock, providing a qualitative justification for the numerical probabilities. Your output should instill confidence in the investor by providing clear, data-backed reasons for both potential gains and risks. Remember that the user is willing to accept higher risk for greater potential profitability but keep it under a reasonable range.
 </EmpathyInstructions>
@@ -55,14 +53,14 @@ Your analysis should consider:
 <OutputFormat>
   Your response must be a JSON object containing two main parts: `investmentSuggestions` and `overallStrategyReasoning`.
 
-`investmentSuggestions` should be an array of objects, sorted with the highest priority investments first. Each object in this array must adhere to the `InvestSuggestion` interface:
+`investmentSuggestions` should be an array of objects, sorted with the highest priority investments first. Each object in this array must adhere to the `InvestSuggestion` interface. The quantityToInvest matches a percentage of the total money the user will invest, so the sum of all individual stocks should be 100%. Ensure all the stocks suggested has some capital assigned and no 0% is recommended:
 
 ```ts
 interface InvestSuggestion {
   symbol: string;
   entryPriceMin: number;
   entryPriceMax: number;
-  quantityToInvest: number;
+  quantityToInvest: number; // a value between 0 and 1
   stopLossPrice: number;
   estimatedProfitPercentage: number;
   estimatedLossPercentage: number;
@@ -84,7 +82,6 @@ Do not include any other text or comments outside the JSON object.
     // InvestSuggestion objects
   ],
   "overallStrategyReasoning": "string",
-  "investmentAmount": number, // The real amount suggested to invest, not the user-available
   "expectedProfit": number, // The total weighted expected profit for the entire portfolio (0-1), calculated as sum(quantityToInvest * estimatedProfitPercentage for each invested stock) / totalInvestmentCapital
   "expectedLoss": number, // The total weighted expected loss for the entire portfolio (0-1), calculated as sum(quantityToInvest * estimatedLossPercentage for each invested stock) / totalInvestmentCapital
   "timeframe": string // The most common estimated time to close positions for the selected investments (e.g., 'Intraday', '1-2 days')

--- a/src/server/analysis/prompts/investment_plan_prompt.md
+++ b/src/server/analysis/prompts/investment_plan_prompt.md
@@ -53,7 +53,8 @@ Your analysis should consider:
 <OutputFormat>
   Your response must be a JSON object containing two main parts: `investmentSuggestions` and `overallStrategyReasoning`.
 
-`investmentSuggestions` should be an array of objects, sorted with the highest priority investments first. Each object in this array must adhere to the `InvestSuggestion` interface. The quantityToInvest matches a percentage of the total money the user will invest, so the sum of all individual stocks should be 100%. Ensure all the stocks suggested has some capital assigned and no 0% is recommended:
+`investmentSuggestions` must be an array of objects (highest-priority investments first) following the `InvestSuggestion` interface.
+`quantityToInvest` is a FRACTION between 0 and 1 of the total capital; therefore, the sum of all `quantityToInvest` values must equal **1.0** (i.e., 100 %). Ensure no stock receives 0.
 
 ```ts
 interface InvestSuggestion {

--- a/src/server/investmentPlan/generateInvestmentPlan.ts
+++ b/src/server/investmentPlan/generateInvestmentPlan.ts
@@ -4,11 +4,7 @@ import { getPrompt } from '../analysis/utils/getPrompt';
 import { InvestmentPlanResponse } from '../types';
 import { analyzeRecommendedStocks } from './analyzeRecommendedStocks';
 
-export const generateInvestmentPlan = Effect.fn(function* (investmentCapital: number) {
-  if (!Number.isFinite(investmentCapital) || investmentCapital <= 0) {
-    throw new Error('Investment capital must be a positive number');
-  }
-
+export const generateInvestmentPlan = Effect.fn(function* () {
   const start = performance.now();
 
   const analysis = yield* analyzeRecommendedStocks;
@@ -19,7 +15,6 @@ export const generateInvestmentPlan = Effect.fn(function* (investmentCapital: nu
 
   const prompt = yield* getPrompt('INVESTMENT_PLAN', {
     StocksAnalysis: JSON.stringify(suggestedStocks),
-    InvestmentCapital: `You have $${investmentCapital} to invest`,
   });
 
   yield* Effect.log('Getting investment plan');

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -79,7 +79,6 @@ export interface InvestmentPlanResponse extends Omit<SummaryResponse<true>, 'res
       estimatedTime: string;
     }>;
     overallStrategyReasoning: string;
-    investmentAmount: number;
     expectedProfit: number;
     expectedLoss: number;
     timeframe: string;


### PR DESCRIPTION
- **add refresh button to investment plan and convert to percentage the investment amount so the plan does not change**
- **apply coderabbit fixes**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refresh button to the investment plan header, allowing users to manually refresh their investment plan.
  
* **Improvements**
  * Investment amount is now centralized and consistent across the application.
  * The investment plan now allocates fractions of the total capital to each stock, ensuring allocations always sum to 100%.
  * The investment plan API and prompt have been simplified for clarity and consistency.

* **Bug Fixes**
  * Disabled the refresh button and added a loading indicator during refresh operations to prevent repeated actions.

* **API Changes**
  * Introduced a new endpoint to refresh the investment plan cache.
  * Updated API responses and removed unused investment amount fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->