### PR TITLE
Set language to English (US) in getPrompt.ts replacement map

### DIFF
--- a/src/server/analysis/utils/getPrompt.ts
+++ b/src/server/analysis/utils/getPrompt.ts
@@ -19,7 +19,7 @@ export function getPrompt<T extends PromptsNames>(
         ...replaces,
         ...{
           Date: `The current date is: ${new Date().toISOString()}`,
-          Language: `You should always answer in: "Spanish - Spain"`,
+          Language: `You should always answer in: "English - United States"`,
         },
       };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Updated the default AI response language to English (United States), replacing Spanish (Spain). Users will now see prompts and generated content in U.S. English conventions across the experience. Date handling remains the same. This change affects on-screen copy, system guidance, and interactive outputs for greater consistency. No other behavior or interface elements were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->